### PR TITLE
Modal partial for photo preview

### DIFF
--- a/app/assets/stylesheets/components/_custom-containers.scss
+++ b/app/assets/stylesheets/components/_custom-containers.scss
@@ -3,3 +3,24 @@
   margin: 0 auto;
 }
 
+.btn {
+  background: $light-gray;
+  border: 0.5px solid $mid-gray;
+  color: $gray;
+  padding: 8px 32px;
+  border-radius: 8px;
+
+  .btn:hover {
+    opacity: 0.7;
+  }
+}
+
+.btn.active {
+  background: $pale-red;
+  border: 0.5px solid $light-gray;
+  color: $light-gray;
+
+  .btn.active:hover {
+    opacity: 0.7;
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -14,6 +14,7 @@
 
 // Camera page.
 @import "ar-overlay";
+@import "photo-preview";
 
 // External imports.
 @import url('https://fonts.googleapis.com/css2?family=Asap:wght@400;500;600&display=swap');

--- a/app/assets/stylesheets/components/_photo-preview.scss
+++ b/app/assets/stylesheets/components/_photo-preview.scss
@@ -1,0 +1,23 @@
+.modal-content {
+  border-radius: 8px;
+  background: $white;
+  opacity: 0.95;
+  border: $light-gray 0.5px;
+  box-shadow: 4px 8px 4px rgba(0, 0, 0, 0.25);
+}
+
+.modal-body {
+  margin: 0 auto;
+}
+
+.modal-title {
+  width: 100%;
+  text-align: center;
+}
+
+.modal-body .modal-image {
+  width: 50vw;
+}
+
+.photo-preview .modal-content {
+}

--- a/app/assets/stylesheets/components/_text.scss
+++ b/app/assets/stylesheets/components/_text.scss
@@ -15,3 +15,19 @@ p {
   font-size: 12px;
   font-weight: 400;
 }
+
+// This is for the heading of the modal (_photo_preview.html.erb)
+h5 {
+  font-family: 'Asap', sans-serif;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+// This is for the buttons of the modal (_photo_preview.html.erb)
+.photo-preview .modal-content {
+  button {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  }
+}

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -7,6 +7,7 @@ $yellow: #FFC65A;
 $orange: #E67E22;
 $green: #1EDD88;
 $gray: #424242;
+$mid-gray: #DADADA;
 $light-gray: #F4F4F4;
 $light: #f7f7f7;
 $white: #FFFFFF;

--- a/app/views/memories/_ar_overlay.html.erb
+++ b/app/views/memories/_ar_overlay.html.erb
@@ -8,7 +8,6 @@
     </button>
   </div>
 
-  <!-- <div class="selected-avatar"></div> -->
   <div class="avatar-list py-2">
     <% avatars.each_with_index do |avatar, index| %>
       <div data-avatar-id="#avatar-<%=index%>" data-action="click->ar-overlay#getIndex">
@@ -17,6 +16,14 @@
     <% end %>
   </div>
 
+ <!--  This button is to be replaced by the camera button once it is linked
+  Expected behaviour - click on capture button, modal (photo preview) pops up -->
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModalCenter">
+    Launch modal
+  </button>
+
+  <!-- This would render the HTML and JS for the modal (to preview photo) -->
+  <%= render 'shared/photo_preview' %>
   <%= render 'shared/camera_shutter' %>
 
 </div>

--- a/app/views/shared/_photo_preview.html.erb
+++ b/app/views/shared/_photo_preview.html.erb
@@ -1,0 +1,36 @@
+<!-- Bootstrap Modal -->
+<div class="photo-preview">
+  <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLongTitle">Preview</h5>
+          <!-- <button type="button" class="close" data-dismiss="modal" aria-label="Close"> -->
+            <!-- <span aria-hidden="true"><i class="fas fa-times"></i></span> -->
+          <!-- </button> -->
+        </div>
+        <div class="modal-body">
+          <!-- Portrait image -->
+          <!-- <img class="modal-image" src="https://res.cloudinary.com/asdfghjk/image/upload/v1600790981/memories_sample/29AC732C-562F-4D8C-9DDA-00DCE0DE76E2_gmb9j2.jpg" alt=""> -->
+
+          <!-- Landscape image -->
+          <img class="modal-image" src="https://images.unsplash.com/photo-1508672019048-805c876b67e2?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1093&q=80" alt="">
+        </div>
+        <div class="modal-footer d-flex justify-content-center">
+
+          <!-- This tag would dismiss the modal -->
+          <button type="button" class="btn" data-dismiss="modal">
+            <i class="fas fa-undo-alt"></i>
+            <span>Retake</span>
+          </button>
+
+          <!-- To add a link to publish image -->
+          <button type="button" class="btn active">
+            <i class="fas fa-upload"></i>
+            <span>Publish</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
@niliaaa I made some changes besides creating the modal partial for photo preview: 
1. Customised button colours (added onto `_custom-containers.scss`) — normal is gray; active is pale-red
2. Customised text of modals under `_text.scss` 
3. Added a `$mid-gray` variable (mainly used for border and text with light-gray background 

Regarding modal partial for photo preview: 
1. Added a button onto `_ar_overlay.html.erb` which is to be replaced by the camera button once it is ready 
2. Expected behaviour - click on capture button, modal (photo preview) pops up
3. I took into consideration landscape & portrait sizes (but I would need to test on actual phone to know it works fine) 
4. Modal scripts were from Bootstrap

![image](https://user-images.githubusercontent.com/64075135/94338170-d9ece080-0022-11eb-8df3-0af34de3d29b.png)

![image](https://user-images.githubusercontent.com/64075135/94338189-f1c46480-0022-11eb-8e46-943250e72e19.png)
